### PR TITLE
Treat grants as a Set instead of List to avoid ordering-based changes detection.

### DIFF
--- a/influxdb/resource_user.go
+++ b/influxdb/resource_user.go
@@ -167,7 +167,7 @@ func readGrants(d *schema.ResourceData, meta interface{}) error {
 		if result[1].(string) != "NO PRIVILEGES" {
 			var grant = map[string]string{
 				"database":  result[0].(string),
-				"privilege": strings.ToLower(result[1].(string)),
+				"privilege": strings.Replace(strings.ToLower(result[1].(string)), "all privileges", "all", 1),
 			}
 			grants = append(grants, grant)
 		}

--- a/influxdb/resource_user.go
+++ b/influxdb/resource_user.go
@@ -43,6 +43,16 @@ func resourceUser() *schema.Resource {
 						"privilege": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+								value := v.(string)
+								switch value {
+								case "READ", "WRITE", "ALL":
+								default:
+									errors = append(errors, fmt.Errorf(
+										"%q must be one of following values: (READ|WRITE|ALL). Please use uppercase values only", k))
+								}
+								return
+							},
 						},
 					},
 				},
@@ -167,7 +177,7 @@ func readGrants(d *schema.ResourceData, meta interface{}) error {
 		if result[1].(string) != "NO PRIVILEGES" {
 			var grant = map[string]string{
 				"database":  result[0].(string),
-				"privilege": strings.Replace(strings.ToLower(result[1].(string)), "all privileges", "all", 1),
+				"privilege": strings.Replace(strings.ToUpper(result[1].(string)), "ALL PRIVILEGES", "ALL", 1),
 			}
 			grants = append(grants, grant)
 		}

--- a/influxdb/resource_user.go
+++ b/influxdb/resource_user.go
@@ -32,7 +32,7 @@ func resourceUser() *schema.Resource {
 				Computed: true,
 			},
 			"grant": &schema.Schema{
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -79,7 +79,7 @@ func createUser(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(fmt.Sprintf("influxdb-user:%s", name))
 
 	if v, ok := d.GetOk("grant"); ok {
-		grants := v.([]interface{})
+		grants := v.(*schema.Set).List()
 		for _, vv := range grants {
 			grant := vv.(map[string]interface{})
 			if err := grantPrivilegeOn(conn, grant["privilege"].(string), grant["database"].(string), name); err != nil {
@@ -190,8 +190,8 @@ func updateUser(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("grant") {
 		oldGrantV, newGrantV := d.GetChange("grant")
-		oldGrant := oldGrantV.([]interface{})
-		newGrant := newGrantV.([]interface{})
+		oldGrant := oldGrantV.(*schema.Set).List()
+		newGrant := newGrantV.(*schema.Set).List()
 
 		for _, oGV := range oldGrant {
 			oldGrant := oGV.(map[string]interface{})

--- a/influxdb/resource_user_test.go
+++ b/influxdb/resource_user_test.go
@@ -307,7 +307,7 @@ resource "influxdb_user" "test" {
 
     grant {
       database = "${influxdb_database.green.name}"
-      privilege = "read"
+      privilege = "READ"
     }
 }
 `
@@ -343,17 +343,17 @@ resource "influxdb_user" "test" {
 
     grant {
       database = "${influxdb_database.red.name}"
-      privilege = "all"
+      privilege = "ALL"
     }
 
     grant {
       database = "${influxdb_database.green.name}"
-      privilege = "write"
+      privilege = "WRITE"
     }
 
     grant {
       database = "${influxdb_database.blue.name}"
-      privilege = "read"
+      privilege = "READ"
     }
 }
 `

--- a/influxdb/resource_user_test.go
+++ b/influxdb/resource_user_test.go
@@ -76,6 +76,7 @@ func TestAccInfluxDBUser_grant(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserGrants("influxdb_user.test", "terraform-green", "WRITE"),
 					testAccCheckUserGrants("influxdb_user.test", "terraform-blue", "READ"),
+					testAccCheckUserGrants("influxdb_user.test", "terraform-red", "ALL PRIVILEGES"),
 					resource.TestCheckResourceAttr(
 						"influxdb_user.test", "name", "terraform_test",
 					),
@@ -86,7 +87,7 @@ func TestAccInfluxDBUser_grant(t *testing.T) {
 						"influxdb_user.test", "admin", "false",
 					),
 					resource.TestCheckResourceAttr(
-						"influxdb_user.test", "grant.#", "2",
+						"influxdb_user.test", "grant.#", "3",
 					),
 				),
 			},
@@ -324,6 +325,10 @@ resource "influxdb_user" "test" {
 `
 
 var testAccUserConfig_grantUpdate = `
+resource "influxdb_database" "red" {
+    name = "terraform-red"
+}
+
 resource "influxdb_database" "green" {
     name = "terraform-green"
 }
@@ -335,6 +340,11 @@ resource "influxdb_database" "blue" {
 resource "influxdb_user" "test" {
     name = "terraform_test"
     password = "terraform"
+
+    grant {
+      database = "${influxdb_database.red.name}"
+      privilege = "all"
+    }
 
     grant {
       database = "${influxdb_database.green.name}"


### PR DESCRIPTION
Fixes #6 
1. Treat grants as a Set instead of List to avoid ordering-based changes detection.
2. [Extra] Treat 'ALL' and 'ALL PRIVILEGES' as the same level of grant.