### PR TITLE
fixed: ping test would fail during `terraform apply`

### DIFF
--- a/influxdb/provider.go
+++ b/influxdb/provider.go
@@ -62,11 +62,6 @@ func configure(d *schema.ResourceData) (interface{}, error) {
 		return nil, err
 	}
 
-	_, _, err = conn.Ping()
-	if err != nil {
-		return nil, fmt.Errorf("error pinging server: %s", err)
-	}
-
 	return conn, nil
 }
 


### PR DESCRIPTION
This fixes the issue described in issue #9 It looks like the code assumes that an InfluxBD is already provision when using the InfluxDB provider.
I’m provisioning the InfluxDB and then configuring it with the InfluxDB provider in the same template. I removed the code that attempts to ping the InfluxDB instance. This allows `terraform apply` to continue.