### PR TITLE
Add ability to bypass certificate authority check if, say, the https-enabled server uses a self-signed cert

### DIFF
--- a/influxdb/provider.go
+++ b/influxdb/provider.go
@@ -39,6 +39,11 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("INFLUXDB_PASSWORD", ""),
 			},
+			"skip_ssl_verify": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("INFLUXDB_SKIP_SSL_VERIFY", "0"),
+			},
 		},
 
 		ConfigureFunc: configure,
@@ -52,9 +57,10 @@ func configure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	config := client.Config{
-		URL:      *url,
-		Username: d.Get("username").(string),
-		Password: d.Get("password").(string),
+		URL:       *url,
+		Username:  d.Get("username").(string),
+		Password:  d.Get("password").(string),
+		UnsafeSsl: d.Get("skip_ssl_verify").(bool),
 	}
 
 	conn, err := client.NewClient(config)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -24,6 +24,11 @@ The provider configuration block accepts the following arguments:
 * ``password`` - (Optional) The password to use when making requests.
   May alternatively be set via the ``INFLUXDB_PASSWORD`` environment variable.
 
+* ``ssl_skip_verify`` - (Optional) If HTTPS enabled on server, and TLS/SSL
+  certificate is, say, self-signed, can set to true to bypass what this client
+  considers insecure server connections. May alternatively be set via the
+  environment (i.e., ``INFLUXDB_SSL_SKIP_VERIFY=1``)
+
 Use the navigation to the left to read about the available resources.
 
 ## Example Usage


### PR DESCRIPTION
Related to the following issue: https://github.com/terraform-providers/terraform-provider-influxdb/issues/11

### Test Results
#### Unit tests:
```
$ make test
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
	xargs -t -n4 go test  -timeout=30s -parallel=4
go test -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-influxdb github.com/terraform-providers/terraform-provider-influxdb/influxdb 
?   	github.com/terraform-providers/terraform-provider-influxdb	[no test files]
ok  	github.com/terraform-providers/terraform-provider-influxdb/influxdb	0.006s
```

#### Acceptance test:
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?   	github.com/terraform-providers/terraform-provider-influxdb	[no test files]
=== RUN   TestAccInfluxDBContiuousQuery
--- PASS: TestAccInfluxDBContiuousQuery (0.27s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccInfluxDBDatabase
--- PASS: TestAccInfluxDBDatabase (0.13s)
=== RUN   TestAccInfluxDBDatabaseWithRPs
--- PASS: TestAccInfluxDBDatabaseWithRPs (0.38s)
=== RUN   TestAccInfluxDBUser_admin
--- PASS: TestAccInfluxDBUser_admin (0.41s)
=== RUN   TestAccInfluxDBUser_grant
--- PASS: TestAccInfluxDBUser_grant (0.89s)
=== RUN   TestAccInfluxDBUser_revoke
--- PASS: TestAccInfluxDBUser_revoke (0.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-influxdb/influxdb	2.592s
```

#### Functional Tests
##### Setting and unsetting the environment variable
```
$  export INFLUXDB_SKIP_SSL_VERIFY=1
$  terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

influxdb_database.demo-test-db-creation: Refreshing state... (ID: demo_test_tf_db)

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
$  export INFLUXDB_SKIP_SSL_VERIFY=0
$  terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.


Error: Error refreshing state: 1 error(s) occurred:

* provider.influxdb: error pinging server: Get https:/<REDACTED>:8443/ping: x509: certificate signed by unknown authority


$  unset INFLUXDB_SKIP_SSL_VERIFY
$  terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.


Error: Error refreshing state: 1 error(s) occurred:

* provider.influxdb: error pinging server: Get https://<REDACTED>:8443/ping: x509: certificate signed by unknown authority
```

##### Updating config to include skip_ssl_verify
```hcl
provider “influxdb” {
 url      = “https://<REDACTED>:8443”
 username = “admin”
 skip_ssl_verify = true
}
```

```
$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.


------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
 + create
...
```