### PR TITLE
Hash and sensitive passwords

### DIFF
--- a/influxdb/provider.go
+++ b/influxdb/provider.go
@@ -37,6 +37,8 @@ func Provider() terraform.ResourceProvider {
 			"password": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Sensitive:   true,
+				StateFunc:   hashSum,
 				DefaultFunc: schema.EnvDefaultFunc("INFLUXDB_PASSWORD", ""),
 			},
 			"skip_ssl_verify": {

--- a/influxdb/resource_user.go
+++ b/influxdb/resource_user.go
@@ -22,9 +22,11 @@ func resourceUser() *schema.Resource {
 				ForceNew: true,
 			},
 			"password": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				Sensitive: true,
+				StateFunc: hashSum,
 			},
 			"admin": {
 				Type:     schema.TypeBool,

--- a/influxdb/utils.go
+++ b/influxdb/utils.go
@@ -1,0 +1,10 @@
+package influxdb
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+func hashSum(contents interface{}) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(contents.(string))))
+}


### PR DESCRIPTION
Added a hash function from similar mysql provider to hash passwords in a state file and mark then as sensitive to not have passwords outputted in a plaintext during plan/apply.