### PR TITLE
Fix documentation on retention policies

### DIFF
--- a/website/docs/r/database.html.md
+++ b/website/docs/r/database.html.md
@@ -14,23 +14,21 @@ The database resource allows a database to be created on an InfluxDB server.
 
 ```hcl
 resource "influxdb_database" "metrics" {
-    name = "awesome_app"
+  name = "awesome_app"
 }
 
 resource "influxdb_database" "metrics_aggregation" {
   name = "testdb11"
-  retention_policies = [
-    {
-      name = "52weeks",
-      duration = "52w"
-      default = "true"
-    },
-    {
-      name = "104weeks",
-      duration = "104w"
-      shardgroupduration = "3d"
-    },
-  ]
+  retention_policies {
+    name = "52weeks"
+    duration = "52w"
+    default = "true"
+  }
+  retention_policies {
+    name = "104weeks"
+    duration = "104w"
+    shardgroupduration = "3d"
+  }
 }
 ```
 

--- a/website/docs/r/user.html.md
+++ b/website/docs/r/user.html.md
@@ -32,8 +32,8 @@ resource "influxdb_user" "paul" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name for the user. 
-* `password` - (Required) The password for the user. 
+* `name` - (Required) The name for the user.
+* `password` - (Required) The password for the user.
 * `admin` - (Optional) Mark the user as admin.
 * `grant` - (Optional) A list of grants for non-admin users
 


### PR DESCRIPTION
Hello,

I noticed that the documentation on retention policies was not up to date since version 1.2 of the InfluxDB provider.

In this version (1.2), the configuration of retention policies has changed (see commit 5bce796).

That's why I made this pull request to modify website/docs/r/database.html.md to correct the documentation on the configuration of retention policies :)

Best regards,
Anthony