### PR TITLE
Add support for the Continuous Query RESAMPLE clause

### DIFF
--- a/influxdb/continuous_query.go
+++ b/influxdb/continuous_query.go
@@ -29,6 +29,12 @@ func resourceContinuousQuery() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"resample": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "",
+			},
 		},
 	}
 }
@@ -38,8 +44,15 @@ func createContinuousQuery(d *schema.ResourceData, meta interface{}) error {
 
 	name := d.Get("name").(string)
 	database := d.Get("database").(string)
+	resample := d.Get("resample").(string)
 
-	queryStr := fmt.Sprintf("CREATE CONTINUOUS QUERY %s ON %s BEGIN %s END", name, quoteIdentifier(database), d.Get("query").(string))
+	var queryStr string
+	if resample == "" {
+		queryStr = fmt.Sprintf("CREATE CONTINUOUS QUERY %s ON %s BEGIN %s END", name, quoteIdentifier(database), d.Get("query").(string))
+	} else {
+		queryStr = fmt.Sprintf("CREATE CONTINUOUS QUERY %s ON %s RESAMPLE %s BEGIN %s END", name, quoteIdentifier(database), resample, d.Get("query").(string))
+	}
+
 	query := client.Query{
 		Command: queryStr,
 	}

--- a/influxdb/continuous_query_test.go
+++ b/influxdb/continuous_query_test.go
@@ -26,6 +26,13 @@ func TestAccInfluxDBContiuousQuery(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"influxdb_continuous_query.minnie", "query", "SELECT min(mouse) INTO min_mouse FROM zoo GROUP BY time(30m)",
 					),
+					testAccCheckContiuousQueryExists("influxdb_continuous_query.minnie_resample"),
+					resource.TestCheckResourceAttr(
+						"influxdb_continuous_query.minnie_resample", "query", "SELECT min(mouse) INTO min_mouse_resampled FROM zoo GROUP BY time(30m)",
+					),
+					resource.TestCheckResourceAttr(
+						"influxdb_continuous_query.minnie_resample", "resample", "EVERY 30m FOR 90m",
+					),
 				),
 			},
 		},
@@ -82,6 +89,13 @@ resource "influxdb_continuous_query" "minnie" {
     name = "minnie"
     database = "${influxdb_database.test.name}"
     query = "SELECT min(mouse) INTO min_mouse FROM zoo GROUP BY time(30m)"
+}
+
+resource "influxdb_continuous_query" "minnie_resample" {
+    name = "minnie_resample"
+    database = "${influxdb_database.test.name}"
+    query = "SELECT min(mouse) INTO min_mouse_resampled FROM zoo GROUP BY time(30m)"
+    resample = "EVERY 30m FOR 90m"
 }
 
 `

--- a/website/docs/r/continuous_query.html.md
+++ b/website/docs/r/continuous_query.html.md
@@ -23,6 +23,13 @@ resource "influxdb_continuous_query" "minnie" {
     query = "SELECT min(mouse) INTO min_mouse FROM zoo GROUP BY time(30m)"
 }
 
+resource "influxdb_continuous_query" "minnie_resample" {
+    name = "minnie_resample"
+    database = "${influxdb_database.test.name}"
+    query = "SELECT min(mouse) INTO min_mouse_resample FROM zoo GROUP BY time(30m)"
+    resample = "EVERY 30m FOR 2h"
+}
+
 ```
 
 ## Argument Reference
@@ -31,7 +38,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name for the continuous_query. This must be unique on the InfluxDB server.
 * `database` - (Required) The database for the continuous_query. This must be an existing influxdb database.
-* `query` - (Required) The query for the continuous_query. 
+* `query` - (Required) The query for the continuous_query.
+* `resample` - (Optional) The body of the query's RESAMPLE clause. The format is detailed in the InfluxDB documentation.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This is very similar in intent to https://github.com/terraform-providers/terraform-provider-influxdb/pull/28, but explicitly supports the `RESAMPLE` clause of advanced continuous query syntax, though the specifics of the RESAMPLE clause are simply passed through.

This also includes an update to the existing tests to cover this new functionality to some degree, which https://github.com/terraform-providers/terraform-provider-influxdb/pull/28 does not.